### PR TITLE
refactor: use EditorProvider to setup Yjs and editor state

### DIFF
--- a/src/frontend/src/main.tsx
+++ b/src/frontend/src/main.tsx
@@ -8,6 +8,7 @@ import { PageLayout } from './PageLayout';
 import { CreateDocumentPage } from './pages/create/CreateDocumentPage';
 import { DocumentPage } from './pages/document/DocumentPage';
 import { LandingPage } from './pages/landing/LandingPage';
+import { EditorProvider } from './shared/context/editor';
 
 const queryClient = new QueryClient();
 
@@ -15,15 +16,17 @@ createRoot(document.getElementById('root')!).render(
   <StrictMode>
     <Theme appearance="dark">
       <QueryClientProvider client={queryClient}>
-        <BrowserRouter>
-          <Routes>
-            <Route path="/" element={<PageLayout />}>
-              <Route index element={<LandingPage />} />
-              <Route path="create" element={<CreateDocumentPage />} />
-              <Route path="document/:documentId" element={<DocumentPage />} />
-            </Route>
-          </Routes>
-        </BrowserRouter>
+        <EditorProvider>
+          <BrowserRouter>
+            <Routes>
+              <Route path="/" element={<PageLayout />}>
+                <Route index element={<LandingPage />} />
+                <Route path="create" element={<CreateDocumentPage />} />
+                <Route path="document/:documentId" element={<DocumentPage />} />
+              </Route>
+            </Routes>
+          </BrowserRouter>
+        </EditorProvider>
       </QueryClientProvider>
     </Theme>
   </StrictMode>,

--- a/src/frontend/src/pages/document/editor-view/EditorView.tsx
+++ b/src/frontend/src/pages/document/editor-view/EditorView.tsx
@@ -66,11 +66,13 @@ const EditorView = ({ file, documentId }: EditorViewProps) => {
       <EditorHeader file={file} pdfEventSource={pdfEventSource} />
       <Group className={styles.panelGroup}>
         <Panel minSize={'20%'} defaultSize="50%" className={styles.panel}>
-          {documentId ? (
-            <LatexEditor content={file?.content ?? ''} users={editorService.users} onEditorMounted={mountEditor} />
-          ) : (
-            'No file selected'
-          )}
+          <div style={{ height: '100%' }} onKeyDown={(e) => e.stopPropagation()}>
+            {documentId ? (
+              <LatexEditor content={file?.content ?? ''} users={editorService.users} onEditorMounted={mountEditor} />
+            ) : (
+              'No file selected'
+            )}
+          </div>
         </Panel>
         <ResizeSeparator onClick={handleSeparatorClick} />
         <Panel collapsible className={styles.panel} minSize="20%" panelRef={rightPanelRef}>

--- a/src/frontend/src/pages/document/editor-view/EditorView.tsx
+++ b/src/frontend/src/pages/document/editor-view/EditorView.tsx
@@ -1,15 +1,12 @@
+import { useEffect, useRef, useState } from 'react';
 import { Group, Panel, type PanelImperativeHandle } from 'react-resizable-panels';
-import LatexEditor, {
-  type AwarenessUser,
-  type AwarenessUserList,
-} from '../../../shared/components/latex-editor/LatexEditor';
-import PDFPreview from '../../../shared/components/pdf-preview/PDFPreview';
-import styles from './EditorView.module.css';
-import ResizeSeparator from '../../../shared/components/separator/ResizeSeparator';
-import EditorHeader from './header/EditorHeader';
-import { useRef, useEffect, useState } from 'react';
 import type { Document } from '../../../features/documents/document';
 import { getPDFRenderedEventSource, type ResilientEventSource } from '../../../features/pdf-preview/api';
+import LatexEditor from '../../../shared/components/latex-editor/LatexEditor';
+import PDFPreview from '../../../shared/components/pdf-preview/PDFPreview';
+import ResizeSeparator from '../../../shared/components/separator/ResizeSeparator';
+import styles from './EditorView.module.css';
+import EditorHeader from './header/EditorHeader';
 
 interface EditorViewProps {
   file: Document | undefined;
@@ -19,8 +16,6 @@ interface EditorViewProps {
 const EditorView = ({ file, documentId }: EditorViewProps) => {
   const rightPanelRef = useRef<PanelImperativeHandle | null>(null);
   const [pdfEventSource, setPdfEventSource] = useState<ResilientEventSource | null>(null);
-  const [awarenessUsers, setAwarenessUsers] = useState<AwarenessUserList>(new Map());
-  const [currentAwarenessUsers, setCurrentAwarenessUsers] = useState<AwarenessUser | null>(null);
 
   useEffect(() => {
     if (!documentId) return;
@@ -52,27 +47,13 @@ const EditorView = ({ file, documentId }: EditorViewProps) => {
 
   return (
     <div className={styles.container}>
-      <EditorHeader
-        file={file}
-        pdfEventSource={pdfEventSource}
-        awarenessUsers={awarenessUsers}
-        currentAwarenessUsers={currentAwarenessUsers}
-      />
+      <EditorHeader file={file} pdfEventSource={pdfEventSource} />
       <Group className={styles.panelGroup}>
         <Panel minSize={'20%'} defaultSize="50%" className={styles.panel}>
           <div style={{ height: '100%' }} onKeyDown={(e) => e.stopPropagation()}>
-            {documentId ? (
-              <LatexEditor
-                roomId={documentId}
-                content={file?.content ?? ''}
-                onAwarenessChange={setAwarenessUsers}
-                onCurrentAwarenessChange={setCurrentAwarenessUsers}
-              />
-            ) : (
-              'No file selected'
-            )}
-          </div>
-        </Panel>
+          	{documentId ? <LatexEditor roomId={documentId} content={file?.content ?? ''} /> : 'No file selected'}
+ 			</div>
+       </Panel>
         <ResizeSeparator onClick={handleSeparatorClick} />
         <Panel collapsible className={styles.panel} minSize="20%" panelRef={rightPanelRef}>
           {documentId ? <PDFPreview docId={documentId} pdfEventSource={pdfEventSource} /> : 'No file selected'}

--- a/src/frontend/src/pages/document/editor-view/EditorView.tsx
+++ b/src/frontend/src/pages/document/editor-view/EditorView.tsx
@@ -1,3 +1,4 @@
+import { editor as monaco } from 'monaco-editor';
 import { useEffect, useRef, useState } from 'react';
 import { Group, Panel, type PanelImperativeHandle } from 'react-resizable-panels';
 import type { Document } from '../../../features/documents/document';
@@ -5,6 +6,7 @@ import { getPDFRenderedEventSource, type ResilientEventSource } from '../../../f
 import LatexEditor from '../../../shared/components/latex-editor/LatexEditor';
 import PDFPreview from '../../../shared/components/pdf-preview/PDFPreview';
 import ResizeSeparator from '../../../shared/components/separator/ResizeSeparator';
+import { useEditorService } from '../../../shared/context/editor';
 import styles from './EditorView.module.css';
 import EditorHeader from './header/EditorHeader';
 
@@ -13,9 +15,19 @@ interface EditorViewProps {
   documentId: string | undefined;
 }
 
+type MonacoEditor = monaco.IStandaloneCodeEditor;
+
 const EditorView = ({ file, documentId }: EditorViewProps) => {
   const rightPanelRef = useRef<PanelImperativeHandle | null>(null);
   const [pdfEventSource, setPdfEventSource] = useState<ResilientEventSource | null>(null);
+  const editorService = useEditorService();
+
+  useEffect(() => {
+    if (documentId && file && editorService.isInitialized) {
+      editorService.joinRoom(documentId, file.content);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [documentId, file, editorService.isInitialized]);
 
   useEffect(() => {
     if (!documentId) return;
@@ -45,15 +57,21 @@ const EditorView = ({ file, documentId }: EditorViewProps) => {
     }
   };
 
+  function mountEditor(editor: MonacoEditor) {
+    editorService.init(editor);
+  }
+
   return (
     <div className={styles.container}>
       <EditorHeader file={file} pdfEventSource={pdfEventSource} />
       <Group className={styles.panelGroup}>
         <Panel minSize={'20%'} defaultSize="50%" className={styles.panel}>
-          <div style={{ height: '100%' }} onKeyDown={(e) => e.stopPropagation()}>
-          	{documentId ? <LatexEditor roomId={documentId} content={file?.content ?? ''} /> : 'No file selected'}
- 			</div>
-       </Panel>
+          {documentId ? (
+            <LatexEditor content={file?.content ?? ''} users={editorService.users} onEditorMounted={mountEditor} />
+          ) : (
+            'No file selected'
+          )}
+        </Panel>
         <ResizeSeparator onClick={handleSeparatorClick} />
         <Panel collapsible className={styles.panel} minSize="20%" panelRef={rightPanelRef}>
           {documentId ? <PDFPreview docId={documentId} pdfEventSource={pdfEventSource} /> : 'No file selected'}

--- a/src/frontend/src/pages/document/editor-view/header/EditorHeader.tsx
+++ b/src/frontend/src/pages/document/editor-view/header/EditorHeader.tsx
@@ -1,26 +1,23 @@
-import { LucideFileCodeCorner, LucidePlay } from 'lucide-react';
-import styles from './EditorHeader.module.css';
 import { Button, Separator, Spinner, Text } from '@radix-ui/themes';
-import { useState, useEffect, useCallback } from 'react';
-import EditorControls from '../controls/EditorControls';
+import { LucideFileCodeCorner, LucidePlay } from 'lucide-react';
+import { useCallback, useEffect, useState } from 'react';
+import { getDocumentTimestamps } from '../../../../features/documents/api';
 import type { Document } from '../../../../features/documents/document';
 import {
-  requestPDFRender,
   COMPILE_FINISHED_MESSAGE_TYPE,
+  requestPDFRender,
   type ResilientEventSource,
 } from '../../../../features/pdf-preview/api';
-import { getDocumentTimestamps } from '../../../../features/documents/api';
+import EditorControls from '../controls/EditorControls';
 import CurrentEditors from './current-editors/CurrentEditors';
-import type { AwarenessUser, AwarenessUserList } from '../../../../shared/components/latex-editor/LatexEditor';
+import styles from './EditorHeader.module.css';
 
 interface EditorHeaderProps {
   file: Document | undefined;
   pdfEventSource: ResilientEventSource | null;
-  awarenessUsers: AwarenessUserList;
-  currentAwarenessUsers: AwarenessUser | null;
 }
 
-const EditorHeader = ({ file, pdfEventSource, awarenessUsers, currentAwarenessUsers }: EditorHeaderProps) => {
+const EditorHeader = ({ file, pdfEventSource }: EditorHeaderProps) => {
   const docId = file?.id;
   const [isCompiling, setIsCompiling] = useState(false);
   const [lastRenderedAt, setLastRenderedAt] = useState<string | null>(null);
@@ -103,11 +100,7 @@ const EditorHeader = ({ file, pdfEventSource, awarenessUsers, currentAwarenessUs
       <Separator orientation="vertical" />
       <EditorControls />
       <Separator orientation="vertical" />
-      <CurrentEditors
-        className={styles.currentEditors}
-        editors={awarenessUsers}
-        currentEditor={currentAwarenessUsers}
-      />
+      <CurrentEditors className={styles.currentEditors} />
       <div style={{ marginRight: '12px', textAlign: 'right' }}>
         {lastChangedAt && now !== null && (
           <Text size="2" color="gray" as="div" style={{ lineHeight: 1.2 }}>

--- a/src/frontend/src/pages/document/editor-view/header/current-editors/CurrentEditors.tsx
+++ b/src/frontend/src/pages/document/editor-view/header/current-editors/CurrentEditors.tsx
@@ -9,9 +9,6 @@ interface CurrentEditorProps {
 const CurrentEditors = ({ className = '' }: CurrentEditorProps) => {
   const { users, currentUser } = useEditorService();
 
-  console.log('users', users);
-  console.log('current user', currentUser);
-
   const editorList = Array.from(users.values()).filter((e) => e.user);
   const otherEditorCount = editorList.length - 2;
   const filteredEditors = currentUser ? editorList.filter((e) => e.clientId !== currentUser.clientId) : editorList;

--- a/src/frontend/src/pages/document/editor-view/header/current-editors/CurrentEditors.tsx
+++ b/src/frontend/src/pages/document/editor-view/header/current-editors/CurrentEditors.tsx
@@ -1,17 +1,20 @@
 import { Text } from '@radix-ui/themes';
 import styles from './CurrentEditor.module.css';
-import type { AwarenessUser, AwarenessUserList } from '../../../../../shared/components/latex-editor/LatexEditor';
+import { useEditorService } from '../../../../../shared/context/editor';
 
 interface CurrentEditorProps {
   className?: string;
-  editors: AwarenessUserList;
-  currentEditor?: AwarenessUser | null;
 }
 
-const CurrentEditors = ({ className = '', editors, currentEditor }: CurrentEditorProps) => {
-  const editorList = Array.from(editors.values()).filter((e) => e.user);
+const CurrentEditors = ({ className = '' }: CurrentEditorProps) => {
+  const { users, currentUser } = useEditorService();
+
+  console.log('users', users);
+  console.log('current user', currentUser);
+
+  const editorList = Array.from(users.values()).filter((e) => e.user);
   const otherEditorCount = editorList.length - 2;
-  const filteredEditors = currentEditor ? editorList.filter((e) => e.clientId !== currentEditor.clientId) : editorList;
+  const filteredEditors = currentUser ? editorList.filter((e) => e.clientId !== currentUser.clientId) : editorList;
 
   return (
     <div className={`${className} ${styles.container}`}>

--- a/src/frontend/src/shared/components/latex-editor/LatexEditor.tsx
+++ b/src/frontend/src/shared/components/latex-editor/LatexEditor.tsx
@@ -1,51 +1,56 @@
 import Editor, { useMonaco } from '@monaco-editor/react';
 import { ThemeContext } from '@radix-ui/themes';
 import { editor as MonacoEditor } from 'monaco-editor';
-import { useContext, useEffect } from 'react';
-import { useEditorService } from '../../context/editor';
+import { memo, useContext, useEffect } from 'react';
+import type { AwarenessUserMap } from '../../context/editor/EditorProvider';
 import Cursors from './cursor/Cursors';
 import styles from './LatexEditor.module.css';
 
 interface LatexEditorProps {
   content: string;
-  roomId: string;
+  users: AwarenessUserMap;
+  onEditorMounted: (editor: MonacoEditor.IStandaloneCodeEditor) => void;
 }
 
-function LatexEditor({ content, roomId }: LatexEditorProps) {
-  const monaco = useMonaco();
-  const editorService = useEditorService();
+const LatexEditor = memo(
+  ({ content, users, onEditorMounted }: LatexEditorProps) => {
+    const monaco = useMonaco();
+    const context = useContext(ThemeContext);
 
-  const context = useContext(ThemeContext);
+    useEffect(() => {
+      if (!monaco) return;
+      monaco.editor.setTheme(context?.appearance === 'dark' ? 'vs-dark' : 'vs-light');
+    }, [monaco, context?.appearance]);
 
-  useEffect(() => {
-    if (!monaco) return;
-    monaco.editor.setTheme(context?.appearance === 'dark' ? 'vs-dark' : 'vs-light');
-  }, [editorService.isInitialized, monaco, context?.appearance]);
+    const handleMount = (editor: MonacoEditor.IStandaloneCodeEditor) => {
+      onEditorMounted(editor);
+    };
 
-  useEffect(() => {
-    if (editorService.isInitialized) {
-      editorService.joinRoom(roomId, content);
-    }
-  }, [editorService.isInitialized, roomId, content]);
+    return (
+      <div className={styles.container}>
+        {users.size > 0 && <Cursors awarenessUsers={users} />}
+        <Editor
+          height="100%"
+          defaultValue={content}
+          defaultLanguage="latex"
+          onMount={handleMount}
+          options={{
+            minimap: { enabled: false },
+          }}
+        />
+      </div>
+    );
+  },
+  (prev, next) => {
+    const previousUsers = [...prev.users.keys()];
+    const nextUsers = [...next.users.keys()];
 
-  const handleMount = (editor: MonacoEditor.IStandaloneCodeEditor) => {
-    editorService.init(editor);
-  };
-
-  return (
-    <div className={styles.container}>
-      {editorService.users.size > 0 && <Cursors awarenessUsers={editorService.users} />}
-      <Editor
-        height="100%"
-        defaultValue={content}
-        defaultLanguage="latex"
-        onMount={handleMount}
-        options={{
-          minimap: { enabled: false },
-        }}
-      />
-    </div>
-  );
-}
+    return (
+      prev.content === next.content &&
+      prev.users.size === next.users.size &&
+      previousUsers.every((user) => nextUsers.includes(user))
+    );
+  },
+);
 
 export default LatexEditor;

--- a/src/frontend/src/shared/components/latex-editor/LatexEditor.tsx
+++ b/src/frontend/src/shared/components/latex-editor/LatexEditor.tsx
@@ -1,206 +1,40 @@
 import Editor, { useMonaco } from '@monaco-editor/react';
-import { useContext, useEffect, useState } from 'react';
-import { MonacoBinding } from 'y-monaco';
-import { WebsocketProvider } from 'y-websocket';
-import * as Y from 'yjs';
-import * as awarenessProtocol from 'y-protocols/awareness';
-import { editor as MonacoEditor, KeyMod, KeyCode } from 'monaco-editor';
 import { ThemeContext } from '@radix-ui/themes';
+import { editor as MonacoEditor } from 'monaco-editor';
+import { useContext, useEffect } from 'react';
+import { useEditorService } from '../../context/editor';
 import Cursors from './cursor/Cursors';
-import { generateColor } from '@marko19907/string-to-color';
-import { adjectives, animals, uniqueNamesGenerator } from 'unique-names-generator';
-import { getDocument } from '../../../features/documents/api';
 import styles from './LatexEditor.module.css';
-
-export type AwarenessUser = {
-  clientId: number;
-  user?: {
-    name?: string;
-    color: string;
-  };
-};
-
-export type AwarenessUserList = Map<number, AwarenessUser>;
 
 interface LatexEditorProps {
   content: string;
   roomId: string;
-  onAwarenessChange?: (users: AwarenessUserList) => void;
-  onCurrentAwarenessChange?: (user: AwarenessUser | null) => void;
 }
 
-function LatexEditor({ content, roomId, onAwarenessChange, onCurrentAwarenessChange }: LatexEditorProps) {
-  const [editor, setEditor] = useState<MonacoEditor.IStandaloneCodeEditor | null>(null);
-  const [yProvider, setYProvider] = useState<WebsocketProvider>();
+function LatexEditor({ content, roomId }: LatexEditorProps) {
   const monaco = useMonaco();
+  const editorService = useEditorService();
+
   const context = useContext(ThemeContext);
-  const [awarenessUsers, setAwarenessUsers] = useState<AwarenessUserList>(new Map());
 
   useEffect(() => {
     if (!monaco) return;
-
     monaco.editor.setTheme(context?.appearance === 'dark' ? 'vs-dark' : 'vs-light');
-  }, [monaco, context?.appearance, editor]);
+  }, [editorService.isInitialized, monaco, context?.appearance]);
 
   useEffect(() => {
-    if (!monaco || !editor) return;
-
-    const model = editor.getModel();
-    if (!model) return;
-
-    const theme = context?.appearance === 'dark' ? 'vs-dark' : 'vs-light';
-    monaco.editor.setTheme(theme);
-
-    // Force LF line endings for Yjs synchronisation
-    model.setEOL(monaco.editor.EndOfLineSequence.LF);
-
-    const yDoc = new Y.Doc();
-    const yText = yDoc.getText('latech');
-
-    const yProvider = new WebsocketProvider(window.ENV.VITE_WS_HOST, roomId, yDoc);
-
-    // eslint-disable-next-line react-hooks/set-state-in-effect
-    setYProvider(yProvider);
-
-    const binding = new MonacoBinding(yText, model, new Set([editor]), yProvider.awareness);
-    const undoManager = new Y.UndoManager(yText, {
-      trackedOrigins: new Set([binding]),
-    });
-
-    yProvider.on('sync', async (isSynced) => {
-      if (!isSynced) return;
-      const current = yText.toString();
-      if (current.length === 0) {
-        const fresh = await getDocument(roomId);
-        const text = fresh.content?.replace(/\r\n/g, '\n') ?? '';
-        if (text) yText.insert(0, text);
-      } else if (current.includes('\r\n')) {
-        yDoc.transact(() => {
-          yText.delete(0, current.length);
-          yText.insert(0, current.replace(/\r\n/g, '\n'));
-        });
-      }
-      model.setEOL(monaco.editor.EndOfLineSequence.LF);
-    });
-
-    editor.addCommand(KeyMod.CtrlCmd | KeyCode.KeyZ, () => {
-      undoManager.undo();
-    });
-
-    editor.addCommand(KeyMod.CtrlCmd | KeyCode.KeyY, () => {
-      undoManager.redo();
-    });
-
-    editor.addCommand(KeyMod.CtrlCmd | KeyCode.KeyC, () => {
-      editor.trigger('keyboard', 'editor.action.clipboardCopyAction', null);
-    });
-
-    let name = sessionStorage.getItem('latech-username') || '';
-    let color = sessionStorage.getItem('latech-usercolor') || '';
-
-    if (
-      name &&
-      color &&
-      Array.from(yProvider.awareness.getStates().values()).some((state) => state.user?.name === name)
-    ) {
-      name = '';
-      color = '';
+    if (editorService.isInitialized) {
+      editorService.joinRoom(roomId, content);
     }
-
-    if (!name || !color) {
-      const MAX_NAME_GENERATION_ATTEMPTS = 20;
-
-      const usedNames = new Set(
-        Array.from(yProvider.awareness.getStates().values())
-          .map((state) => state.user?.name)
-          .filter((stateName): stateName is string => Boolean(stateName)),
-      );
-
-      let generatedName = '';
-      for (let attempt = 0; attempt < MAX_NAME_GENERATION_ATTEMPTS; attempt++) {
-        const candidateName = uniqueNamesGenerator({
-          dictionaries: [adjectives, animals],
-          style: 'capital',
-        });
-
-        if (!usedNames.has(candidateName)) {
-          generatedName = candidateName;
-          break;
-        }
-      }
-
-      if (!generatedName) {
-        const fallbackBaseName = uniqueNamesGenerator({
-          dictionaries: [adjectives, animals],
-          style: 'capital',
-        });
-        const fallbackSuffix = Math.random().toString(36).slice(2, 8);
-        generatedName = `${fallbackBaseName}${fallbackSuffix}`;
-      }
-
-      name = generatedName;
-      color = generateColor(name);
-      sessionStorage.setItem('latech-username', name);
-      sessionStorage.setItem('latech-usercolor', color);
-    }
-
-    // Clean up awareness state on window unload
-    const handleWindowUnload = () => {
-      awarenessProtocol.removeAwarenessStates(yProvider.awareness, [yProvider.doc.clientID], 'window unload');
-    };
-
-    window.addEventListener('beforeunload', handleWindowUnload);
-
-    yProvider.awareness.setLocalStateField('user', {
-      name: name,
-      color: color,
-    });
-
-    return () => {
-      binding.destroy();
-      yProvider.awareness.destroy();
-      yProvider.destroy();
-      yDoc.destroy();
-      undoManager.destroy();
-      window.removeEventListener('beforeunload', handleWindowUnload);
-    };
-  }, [editor, monaco, roomId, onAwarenessChange, onCurrentAwarenessChange]);
-
-  useEffect(() => {
-    if (!yProvider) return;
-
-    function setUsers() {
-      const users: AwarenessUserList = new Map(
-        Array.from(yProvider!.awareness.getStates().entries()).map(([clientId, state]) => [
-          clientId,
-          {
-            clientId,
-            user: state.user,
-          },
-        ]),
-      );
-
-      setAwarenessUsers(users);
-      onAwarenessChange?.(users);
-      onCurrentAwarenessChange?.(users.get(yProvider!.awareness.clientID) || null);
-    }
-
-    setUsers();
-
-    yProvider.awareness.on('change', setUsers);
-
-    return () => {
-      yProvider.awareness.off('change', setUsers);
-    };
-  }, [yProvider, onAwarenessChange, onCurrentAwarenessChange]);
+  }, [editorService.isInitialized, roomId, content]);
 
   const handleMount = (editor: MonacoEditor.IStandaloneCodeEditor) => {
-    setEditor(editor);
+    editorService.init(editor);
   };
 
   return (
     <div className={styles.container}>
-      {yProvider && <Cursors awarenessUsers={awarenessUsers} />}
+      {editorService.users.size > 0 && <Cursors awarenessUsers={editorService.users} />}
       <Editor
         height="100%"
         defaultValue={content}

--- a/src/frontend/src/shared/components/latex-editor/cursor/Cursors.tsx
+++ b/src/frontend/src/shared/components/latex-editor/cursor/Cursors.tsx
@@ -1,8 +1,8 @@
 import { useMemo } from 'react';
-import type { AwarenessUserList } from '../LatexEditor';
+import type { AwarenessUserMap } from '../../../context/editor/hook';
 
 interface CursorsProps {
-  awarenessUsers: AwarenessUserList;
+  awarenessUsers: AwarenessUserMap;
 }
 
 const Cursors = ({ awarenessUsers }: CursorsProps) => {

--- a/src/frontend/src/shared/components/latex-editor/cursor/Cursors.tsx
+++ b/src/frontend/src/shared/components/latex-editor/cursor/Cursors.tsx
@@ -1,5 +1,5 @@
 import { useMemo } from 'react';
-import type { AwarenessUserMap } from '../../../context/editor/hook';
+import type { AwarenessUserMap } from '../../../context/editor/EditorProvider';
 
 interface CursorsProps {
   awarenessUsers: AwarenessUserMap;

--- a/src/frontend/src/shared/context/editor/EditorProvider.tsx
+++ b/src/frontend/src/shared/context/editor/EditorProvider.tsx
@@ -1,0 +1,169 @@
+import { generateColor } from '@marko19907/string-to-color';
+import { KeyCode, KeyMod, editor as monaco } from 'monaco-editor';
+import type { PropsWithChildren } from 'react';
+import { useCallback, useState, type EffectCallback } from 'react';
+import { adjectives, animals, uniqueNamesGenerator } from 'unique-names-generator';
+import { MonacoBinding } from 'y-monaco';
+import { Awareness, removeAwarenessStates } from 'y-protocols/awareness';
+import { WebsocketProvider } from 'y-websocket';
+import { Doc, UndoManager } from 'yjs';
+import { EditorContext } from './context';
+
+type MonacoEditor = monaco.IStandaloneCodeEditor;
+
+export interface EditorService {
+  isInitialized: boolean;
+  currentUser: AwarenessUser | null;
+  users: AwarenessUserMap;
+
+  init: (editor: MonacoEditor) => void;
+  joinRoom: (roomId: string, initialContent: string) => EffectCallback;
+}
+
+export type AwarenessUser = {
+  clientId: number;
+  user?: {
+    name?: string;
+    color: string;
+  };
+};
+
+export type AwarenessUserMap = Map<number, AwarenessUser>;
+
+export function EditorProvider({ children }: PropsWithChildren) {
+  const [monacoEditor, setMonacoEditor] = useState<MonacoEditor | null>(null);
+  const [awarenessUsers, setAwarenessUsers] = useState<AwarenessUserMap>(new Map());
+  const [currentAwarenessUser, setCurrentAwarenessUser] = useState<AwarenessUser | null>(null);
+
+  const editorService: EditorService = {
+    isInitialized: Boolean(monacoEditor),
+    users: awarenessUsers,
+    currentUser: currentAwarenessUser,
+
+    init: useCallback((editor) => setMonacoEditor(editor), [setMonacoEditor]),
+    joinRoom: (roomId: string, initialContent: string) => {
+      const model = monacoEditor?.getModel();
+      if (!monacoEditor || !model) return () => {};
+
+      // Connect to Yjs document
+      const yDoc = new Doc();
+      const yText = yDoc.getText('latech');
+      const yProvider = new WebsocketProvider(window.ENV.VITE_WS_HOST, roomId, yDoc);
+
+      // Initialize the editor content with the provided content if the Yjs document is empty
+      yProvider.on('sync', (isSynced) => {
+        if (isSynced && yText.toString().length === 0 && initialContent) {
+          yText.insert(0, initialContent);
+        }
+      });
+
+      // Setup undo/redo commands
+      const binding = new MonacoBinding(yText, model, new Set([monacoEditor]), yProvider.awareness);
+      const undoManager = new UndoManager(yText, {
+        trackedOrigins: new Set([binding]),
+      });
+      monacoEditor.addCommand(KeyMod.CtrlCmd | KeyCode.KeyZ, () => {
+        undoManager.undo();
+      });
+
+      monacoEditor.addCommand(KeyMod.CtrlCmd | KeyCode.KeyY, () => {
+        undoManager.redo();
+      });
+
+      // Cursor positioning
+      const currentUserId = yDoc.clientID;
+      const awareness = yProvider.awareness;
+      const cleanupAwarenessStates = () => {
+        removeAwarenessStates(awareness, [currentUserId], 'window unload');
+      };
+      window.addEventListener('beforeunload', cleanupAwarenessStates);
+
+      const awarenessUser = getAwarenessUserInfo(yProvider.awareness);
+      awareness.setLocalStateField('user', awarenessUser);
+
+      const setupAwarenessUsers = () => {
+        const allUsers = getActiveAwarenessUsers(awareness);
+
+        setAwarenessUsers(allUsers);
+        setCurrentAwarenessUser(allUsers.get(currentUserId) || null);
+      };
+
+      awareness.on('change', setupAwarenessUsers);
+      setupAwarenessUsers();
+
+      // Cleanup function
+      return () => {
+        binding.destroy();
+        awareness.destroy();
+        yProvider.destroy();
+        yDoc.destroy();
+        undoManager.destroy();
+        window.removeEventListener('beforeunload', cleanupAwarenessStates);
+        awareness.off('change', setupAwarenessUsers);
+      };
+    },
+  };
+
+  function getActiveAwarenessUsers(awareness: Awareness): AwarenessUserMap {
+    return new Map(
+      Array.from(awareness.getStates().entries()).map(([clientId, state]) => [
+        clientId,
+        {
+          clientId,
+          user: state.user,
+        },
+      ]),
+    );
+  }
+
+  function getAwarenessUserInfo(awareness: Awareness) {
+    let name = sessionStorage.getItem('latech-username') || '';
+    let color = sessionStorage.getItem('latech-usercolor') || '';
+
+    if (name && color && Array.from(awareness.getStates().values()).some((state) => state.user?.name === name)) {
+      name = '';
+      color = '';
+    }
+
+    if (!name || !color) {
+      const MAX_NAME_GENERATION_ATTEMPTS = 20;
+
+      const usedNames = new Set(
+        Array.from(awareness.getStates().values())
+          .map((state) => state.user?.name)
+          .filter((stateName): stateName is string => Boolean(stateName)),
+      );
+
+      let generatedName = '';
+      for (let attempt = 0; attempt < MAX_NAME_GENERATION_ATTEMPTS; attempt++) {
+        const candidateName = uniqueNamesGenerator({
+          dictionaries: [adjectives, animals],
+          style: 'capital',
+        });
+
+        if (!usedNames.has(candidateName)) {
+          generatedName = candidateName;
+          break;
+        }
+      }
+
+      if (!generatedName) {
+        const fallbackBaseName = uniqueNamesGenerator({
+          dictionaries: [adjectives, animals],
+          style: 'capital',
+        });
+        const fallbackSuffix = Math.random().toString(36).slice(2, 8);
+        generatedName = `${fallbackBaseName}${fallbackSuffix}`;
+      }
+
+      name = generatedName;
+      color = generateColor(name);
+      sessionStorage.setItem('latech-username', name);
+      sessionStorage.setItem('latech-usercolor', color);
+
+      return { name, color };
+    }
+  }
+
+  return <EditorContext.Provider value={editorService}>{children}</EditorContext.Provider>;
+}

--- a/src/frontend/src/shared/context/editor/EditorProvider.tsx
+++ b/src/frontend/src/shared/context/editor/EditorProvider.tsx
@@ -1,5 +1,5 @@
 import { generateColor } from '@marko19907/string-to-color';
-import { KeyCode, KeyMod, editor as monaco } from 'monaco-editor';
+import { editor, KeyCode, KeyMod, editor as monaco } from 'monaco-editor';
 import type { PropsWithChildren } from 'react';
 import { useCallback, useState, type EffectCallback } from 'react';
 import { adjectives, animals, uniqueNamesGenerator } from 'unique-names-generator';
@@ -45,6 +45,8 @@ export function EditorProvider({ children }: PropsWithChildren) {
       const model = monacoEditor?.getModel();
       if (!monacoEditor || !model) return () => {};
 
+      model.setEOL(editor.EndOfLineSequence.LF);
+
       // Connect to Yjs document
       const yDoc = new Doc();
       const yText = yDoc.getText('latech');
@@ -52,12 +54,21 @@ export function EditorProvider({ children }: PropsWithChildren) {
 
       // Initialize the editor content with the provided content if the Yjs document is empty
       yProvider.on('sync', (isSynced) => {
-        if (isSynced && yText.toString().length === 0 && initialContent) {
-          yText.insert(0, initialContent);
+        if (!isSynced) return;
+
+        const current = yText.toString();
+        if (current.length === 0 && initialContent) {
+          yText.insert(0, initialContent.replace(/\r\n/g, '\n'));
+        } else if (current.includes('\r\n')) {
+          yDoc.transact(() => {
+            yText.delete(0, current.length);
+            yText.insert(0, current.replace(/\r\n/g, '\n'));
+          });
         }
+        model.setEOL(editor.EndOfLineSequence.LF);
       });
 
-      // Setup undo/redo commands
+      // Setup editor commands
       const binding = new MonacoBinding(yText, model, new Set([monacoEditor]), yProvider.awareness);
       const undoManager = new UndoManager(yText, {
         trackedOrigins: new Set([binding]),
@@ -68,6 +79,10 @@ export function EditorProvider({ children }: PropsWithChildren) {
 
       monacoEditor.addCommand(KeyMod.CtrlCmd | KeyCode.KeyY, () => {
         undoManager.redo();
+      });
+
+      monacoEditor.addCommand(KeyMod.CtrlCmd | KeyCode.KeyC, () => {
+        monacoEditor.trigger('keyboard', 'editor.action.clipboardCopyAction', null);
       });
 
       // Cursor positioning

--- a/src/frontend/src/shared/context/editor/context.ts
+++ b/src/frontend/src/shared/context/editor/context.ts
@@ -1,0 +1,4 @@
+import { createContext } from 'react';
+import type { EditorService } from './EditorProvider';
+
+export const EditorContext = createContext<EditorService | null>(null);

--- a/src/frontend/src/shared/context/editor/hook.ts
+++ b/src/frontend/src/shared/context/editor/hook.ts
@@ -1,0 +1,12 @@
+import { useContext } from 'react';
+import { EditorContext } from './context';
+
+export function useEditorService() {
+  const context = useContext(EditorContext);
+
+  if (!context) {
+    throw new Error('useEditorService must be used inside EditorProvider');
+  }
+
+  return context;
+}

--- a/src/frontend/src/shared/context/editor/index.ts
+++ b/src/frontend/src/shared/context/editor/index.ts
@@ -1,0 +1,2 @@
+export { EditorProvider } from './EditorProvider';
+export { useEditorService } from './hook';


### PR DESCRIPTION
- Created `EditorProvider` to abstract away Yjs setup
- Components can use `useEditorService` for reading and mutating editor state.
- Reduced re-render count for `LatexEditor` component, causing less jitter when using the editor.
- Reduced amount of prop-drilling across the `EditorView` component