### PR TITLE
fix(frontend): fix memory leaks and reduce re-renders

### DIFF
--- a/src/frontend/src/pages/document/editor-view/EditorView.tsx
+++ b/src/frontend/src/pages/document/editor-view/EditorView.tsx
@@ -29,14 +29,18 @@ const EditorView = ({ file, documentId }: EditorViewProps) => {
     if (!documentId) return;
 
     const source = getPDFRenderedEventSource(documentId);
+    let isActive = true;
 
     // Using a microtask prevents the synchronous cascading render while
     // keeping the connection cycle tightly bound to the effect.
     Promise.resolve().then(() => {
-      setPdfEventSource(source);
+      if (isActive) {
+        setPdfEventSource(source);
+      }
     });
 
     return () => {
+      isActive = false;
       source.close();
       setPdfEventSource(null);
     };

--- a/src/frontend/src/pages/document/editor-view/header/EditorHeader.tsx
+++ b/src/frontend/src/pages/document/editor-view/header/EditorHeader.tsx
@@ -15,7 +15,7 @@ import {
   type ResilientEventSource,
 } from '../../../../features/pdf-preview/api';
 import CurrentEditors from './current-editors/CurrentEditors';
-import { useEditor } from '../../../../shared/components/latex-editor/EditorContext';
+import { useAwareness } from '../../../../shared/components/latex-editor/EditorContext';
 import { useKeyboardSaveContext } from '../../provider/KeyboardSaveContext';
 import EditorNavigationButtons from './navigation-buttons/EditorNavigationButtons';
 
@@ -31,7 +31,7 @@ const EditorHeader = ({ file, pdfEventSource }: EditorHeaderProps) => {
   const [lastChangedAt, setLastChangedAt] = useState<string | null>(null);
   const [now, setNow] = useState<number>(() => Date.now());
   const [autoRenderEnabled, setAutoRenderEnabled] = useState<boolean>(file?.autoRenderEnabled ?? true);
-  const { awarenessUsers, currentAwarenessUser } = useEditor();
+  const { awarenessUsers, currentAwarenessUser } = useAwareness();
   const { buttonRef } = useKeyboardSaveContext();
 
   useEffect(() => {

--- a/src/frontend/src/pages/document/file-tree/FileTree.tsx
+++ b/src/frontend/src/pages/document/file-tree/FileTree.tsx
@@ -44,27 +44,36 @@ const FileTree = ({ selectedFile, setSelectedFile, onClose }: FileTreeProps) => 
     setSelectedFile({ type: 'tex', file: document });
   }, [isDocumentLoading, setSelectedFile, document, documentUnlocked]);
 
-  const handleOnDownload = useCallback((item: DocumentFile) => {
-    if (item.type === 'image') {
-      downloadMutation.mutateAsync({ imageId: item.file.id, imageName: item.file.name });
-    }
-  }, [downloadMutation]);
+  const handleOnDownload = useCallback(
+    (item: DocumentFile) => {
+      if (item.type === 'image') {
+        downloadMutation.mutateAsync({ imageId: item.file.id, imageName: item.file.name });
+      }
+    },
+    [downloadMutation],
+  );
 
-  const onDelete = useCallback((item: DocumentFile) => {
-    if (item.type === 'image') {
-      deleteQuery.mutateAsync(item.file.id).then(() => {
-        setSelectedFile(undefined);
-      });
-    }
-  }, [deleteQuery, setSelectedFile]);
+  const onDelete = useCallback(
+    (item: DocumentFile) => {
+      if (item.type === 'image') {
+        deleteQuery.mutateAsync(item.file.id).then(() => {
+          setSelectedFile(undefined);
+        });
+      }
+    },
+    [deleteQuery, setSelectedFile],
+  );
 
-  const handleOnNameChange = useCallback((item: DocumentFile, newName: string) => {
-    if (item.type === 'image') {
-      renameMutation.mutateAsync({ imageId: item.file.id, newName });
-    }
+  const handleOnNameChange = useCallback(
+    (item: DocumentFile, newName: string) => {
+      if (item.type === 'image') {
+        renameMutation.mutateAsync({ imageId: item.file.id, newName });
+      }
 
-    // TODO: handle renaming for tex document as well
-  }, [renameMutation]);
+      // TODO: handle renaming for tex document as well
+    },
+    [renameMutation],
+  );
 
   const files: DocumentFile[] = useMemo(
     () => [

--- a/src/frontend/src/pages/document/file-tree/FileTree.tsx
+++ b/src/frontend/src/pages/document/file-tree/FileTree.tsx
@@ -12,7 +12,7 @@ import {
 } from '../../../features/documents/api';
 import { useParams } from 'react-router';
 import type { DocumentFile } from '../DocumentPage';
-import { useEffect, useMemo } from 'react';
+import { useCallback, useEffect, useMemo } from 'react';
 
 interface FileTreeProps {
   setSelectedFile: (file: DocumentFile | undefined) => void;
@@ -44,27 +44,27 @@ const FileTree = ({ selectedFile, setSelectedFile, onClose }: FileTreeProps) => 
     setSelectedFile({ type: 'tex', file: document });
   }, [isDocumentLoading, setSelectedFile, document, documentUnlocked]);
 
-  const handleOnDownload = (item: DocumentFile) => {
+  const handleOnDownload = useCallback((item: DocumentFile) => {
     if (item.type === 'image') {
       downloadMutation.mutateAsync({ imageId: item.file.id, imageName: item.file.name });
     }
-  };
+  }, [downloadMutation]);
 
-  const onDelete = (item: DocumentFile) => {
+  const onDelete = useCallback((item: DocumentFile) => {
     if (item.type === 'image') {
       deleteQuery.mutateAsync(item.file.id).then(() => {
         setSelectedFile(undefined);
       });
     }
-  };
+  }, [deleteQuery, setSelectedFile]);
 
-  const handleOnNameChange = (item: DocumentFile, newName: string) => {
+  const handleOnNameChange = useCallback((item: DocumentFile, newName: string) => {
     if (item.type === 'image') {
       renameMutation.mutateAsync({ imageId: item.file.id, newName });
     }
 
     // TODO: handle renaming for tex document as well
-  };
+  }, [renameMutation]);
 
   const files: DocumentFile[] = useMemo(
     () => [

--- a/src/frontend/src/pages/document/file-tree/item/FileTreeItem.tsx
+++ b/src/frontend/src/pages/document/file-tree/item/FileTreeItem.tsx
@@ -1,7 +1,7 @@
 import styles from './FileTreeItem.module.css';
 import { Text, TextField } from '@radix-ui/themes';
 import FileTreeItemDotMenu from './dot-menu/FileTreeItemDotMenu';
-import { useEffect, useRef, useState } from 'react';
+import { memo, useEffect, useRef, useState } from 'react';
 
 interface FileTreeItemProps {
   fileName: string;
@@ -15,7 +15,7 @@ interface FileTreeItemProps {
   canDownload?: boolean;
 }
 
-const FileTreeItem = ({
+const FileTreeItem = memo(({
   fileName,
   icon,
   isSelected,
@@ -33,10 +33,11 @@ const FileTreeItem = ({
 
   useEffect(() => {
     if (isRenaming) {
-      requestAnimationFrame(() => {
+      const rafId = requestAnimationFrame(() => {
         textFieldRef.current?.focus();
         textFieldRef.current?.select();
       });
+      return () => cancelAnimationFrame(rafId);
     }
   }, [isRenaming]);
 
@@ -80,9 +81,7 @@ const FileTreeItem = ({
   return (
     <div
       className={styles.container}
-      onClick={() => {
-        onClick();
-      }}
+      onClick={onClick}
       onFocus={onClick}
       onKeyUp={handleOnKeyUp}
       data-selected={isSelected}
@@ -119,6 +118,6 @@ const FileTreeItem = ({
       />
     </div>
   );
-};
+});
 
 export default FileTreeItem;

--- a/src/frontend/src/pages/document/file-tree/item/FileTreeItem.tsx
+++ b/src/frontend/src/pages/document/file-tree/item/FileTreeItem.tsx
@@ -15,109 +15,111 @@ interface FileTreeItemProps {
   canDownload?: boolean;
 }
 
-const FileTreeItem = memo(({
-  fileName,
-  icon,
-  isSelected,
-  onClick,
-  onDelete,
-  onNameChange: onRename,
-  onDownload,
-  canDelete,
-  canDownload,
-}: FileTreeItemProps) => {
-  const [isRenaming, setIsRenaming] = useState(false);
-  const textFieldRef = useRef<HTMLInputElement>(null);
-  const [textFieldValue, setTextFieldValue] = useState(fileName);
-  const fileTreeItemRef = useRef<HTMLDivElement>(null);
+const FileTreeItem = memo(
+  ({
+    fileName,
+    icon,
+    isSelected,
+    onClick,
+    onDelete,
+    onNameChange: onRename,
+    onDownload,
+    canDelete,
+    canDownload,
+  }: FileTreeItemProps) => {
+    const [isRenaming, setIsRenaming] = useState(false);
+    const textFieldRef = useRef<HTMLInputElement>(null);
+    const [textFieldValue, setTextFieldValue] = useState(fileName);
+    const fileTreeItemRef = useRef<HTMLDivElement>(null);
 
-  useEffect(() => {
-    if (isRenaming) {
-      const rafId = requestAnimationFrame(() => {
-        textFieldRef.current?.focus();
-        textFieldRef.current?.select();
-      });
-      return () => cancelAnimationFrame(rafId);
-    }
-  }, [isRenaming]);
+    useEffect(() => {
+      if (isRenaming) {
+        const rafId = requestAnimationFrame(() => {
+          textFieldRef.current?.focus();
+          textFieldRef.current?.select();
+        });
+        return () => cancelAnimationFrame(rafId);
+      }
+    }, [isRenaming]);
 
-  useEffect(() => {
-    if (isSelected && !isRenaming) {
-      fileTreeItemRef.current?.focus();
-    }
-  }, [isSelected, isRenaming]);
+    useEffect(() => {
+      if (isSelected && !isRenaming) {
+        fileTreeItemRef.current?.focus();
+      }
+    }, [isSelected, isRenaming]);
 
-  const handleOnRename = () => {
-    setIsRenaming(true);
-  };
+    const handleOnRename = () => {
+      setIsRenaming(true);
+    };
 
-  const handleOnDownload = () => {
-    onDownload();
-  };
+    const handleOnDownload = () => {
+      onDownload();
+    };
 
-  const handleOnDelete = () => {
-    onDelete();
-  };
+    const handleOnDelete = () => {
+      onDelete();
+    };
 
-  const handleOnKeyUp = (e: React.KeyboardEvent) => {
-    if (e.key !== 'Enter') return;
+    const handleOnKeyUp = (e: React.KeyboardEvent) => {
+      if (e.key !== 'Enter') return;
 
-    if (isRenaming) {
+      if (isRenaming) {
+        onRename(textFieldValue);
+      }
+
+      setIsRenaming(!isRenaming);
+    };
+
+    const handleOnBlur = () => {
+      setIsRenaming(false);
       onRename(textFieldValue);
-    }
+    };
 
-    setIsRenaming(!isRenaming);
-  };
+    const handleOnNameChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+      setTextFieldValue(e.target.value);
+    };
 
-  const handleOnBlur = () => {
-    setIsRenaming(false);
-    onRename(textFieldValue);
-  };
-
-  const handleOnNameChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    setTextFieldValue(e.target.value);
-  };
-
-  return (
-    <div
-      className={styles.container}
-      onClick={onClick}
-      onFocus={onClick}
-      onKeyUp={handleOnKeyUp}
-      data-selected={isSelected}
-      tabIndex={0}
-      ref={fileTreeItemRef}
-    >
-      {icon && <div className={styles.icon}>{icon}</div>}
-      {isRenaming ? (
-        <TextField.Root
-          className={styles.textField}
-          size="1"
-          value={textFieldValue}
-          onChange={handleOnNameChange}
-          onBlur={handleOnBlur}
-          ref={textFieldRef}
-          onKeyUp={(e) => {
-            e.stopPropagation();
-            handleOnKeyUp(e);
-          }}
-          autoFocus
+    return (
+      <div
+        className={styles.container}
+        onClick={onClick}
+        onFocus={onClick}
+        onKeyUp={handleOnKeyUp}
+        data-selected={isSelected}
+        tabIndex={0}
+        ref={fileTreeItemRef}
+      >
+        {icon && <div className={styles.icon}>{icon}</div>}
+        {isRenaming ? (
+          <TextField.Root
+            className={styles.textField}
+            size="1"
+            value={textFieldValue}
+            onChange={handleOnNameChange}
+            onBlur={handleOnBlur}
+            ref={textFieldRef}
+            onKeyUp={(e) => {
+              e.stopPropagation();
+              handleOnKeyUp(e);
+            }}
+            autoFocus
+          />
+        ) : (
+          <Text size="1" wrap="nowrap" truncate>
+            {fileName}
+          </Text>
+        )}
+        <FileTreeItemDotMenu
+          className={styles.dotMenu}
+          onRename={handleOnRename}
+          onDownload={handleOnDownload}
+          onDelete={handleOnDelete}
+          canDelete={canDelete}
+          canDownload={canDownload}
         />
-      ) : (
-        <Text size="1" wrap="nowrap" truncate>
-          {fileName}
-        </Text>
-      )}
-      <FileTreeItemDotMenu
-        className={styles.dotMenu}
-        onRename={handleOnRename}
-        onDownload={handleOnDownload}
-        onDelete={handleOnDelete}
-        canDelete={canDelete}
-        canDownload={canDownload}
-      />
-    </div>
-  );
-});
+      </div>
+    );
+  },
+);
 
 export default FileTreeItem;

--- a/src/frontend/src/pages/document/file-tree/item/dot-menu/FileTreeItemDotMenu.tsx
+++ b/src/frontend/src/pages/document/file-tree/item/dot-menu/FileTreeItemDotMenu.tsx
@@ -11,33 +11,28 @@ interface FileTreeItemDotMenuProps {
   canDelete?: boolean;
 }
 
-const FileTreeItemDotMenu = memo(({
-  className,
-  onRename,
-  onDownload,
-  onDelete,
-  canDownload,
-  canDelete,
-}: FileTreeItemDotMenuProps) => {
-  return (
-    <DropdownMenu.Root>
-      <DropdownMenu.Trigger>
-        <LucideEllipsisVertical className={className} size={16} />
-      </DropdownMenu.Trigger>
-      <DropdownMenu.Content>
-        <DropdownMenu.Item onSelect={onRename} shortcut="Enter">
-          Rename
-        </DropdownMenu.Item>
-        <DropdownMenu.Item onSelect={onDownload} disabled={!canDownload}>
-          Download
-        </DropdownMenu.Item>
-        <DropdownMenu.Separator />
-        <DropdownMenu.Item onSelect={onDelete} color="red" disabled={!canDelete}>
-          Delete
-        </DropdownMenu.Item>
-      </DropdownMenu.Content>
-    </DropdownMenu.Root>
-  );
-});
+const FileTreeItemDotMenu = memo(
+  ({ className, onRename, onDownload, onDelete, canDownload, canDelete }: FileTreeItemDotMenuProps) => {
+    return (
+      <DropdownMenu.Root>
+        <DropdownMenu.Trigger>
+          <LucideEllipsisVertical className={className} size={16} />
+        </DropdownMenu.Trigger>
+        <DropdownMenu.Content>
+          <DropdownMenu.Item onSelect={onRename} shortcut="Enter">
+            Rename
+          </DropdownMenu.Item>
+          <DropdownMenu.Item onSelect={onDownload} disabled={!canDownload}>
+            Download
+          </DropdownMenu.Item>
+          <DropdownMenu.Separator />
+          <DropdownMenu.Item onSelect={onDelete} color="red" disabled={!canDelete}>
+            Delete
+          </DropdownMenu.Item>
+        </DropdownMenu.Content>
+      </DropdownMenu.Root>
+    );
+  },
+);
 
 export default FileTreeItemDotMenu;

--- a/src/frontend/src/pages/document/file-tree/item/dot-menu/FileTreeItemDotMenu.tsx
+++ b/src/frontend/src/pages/document/file-tree/item/dot-menu/FileTreeItemDotMenu.tsx
@@ -1,5 +1,6 @@
 import { DropdownMenu } from '@radix-ui/themes';
 import { LucideEllipsisVertical } from 'lucide-react';
+import { memo } from 'react';
 
 interface FileTreeItemDotMenuProps {
   className?: string;
@@ -10,7 +11,7 @@ interface FileTreeItemDotMenuProps {
   canDelete?: boolean;
 }
 
-const FileTreeItemDotMenu = ({
+const FileTreeItemDotMenu = memo(({
   className,
   onRename,
   onDownload,
@@ -24,35 +25,19 @@ const FileTreeItemDotMenu = ({
         <LucideEllipsisVertical className={className} size={16} />
       </DropdownMenu.Trigger>
       <DropdownMenu.Content>
-        <DropdownMenu.Item
-          onSelect={() => {
-            onRename?.();
-          }}
-          shortcut="Enter"
-        >
+        <DropdownMenu.Item onSelect={onRename} shortcut="Enter">
           Rename
         </DropdownMenu.Item>
-        <DropdownMenu.Item
-          onSelect={() => {
-            onDownload?.();
-          }}
-          disabled={!canDownload}
-        >
+        <DropdownMenu.Item onSelect={onDownload} disabled={!canDownload}>
           Download
         </DropdownMenu.Item>
         <DropdownMenu.Separator />
-        <DropdownMenu.Item
-          onSelect={() => {
-            onDelete?.();
-          }}
-          color="red"
-          disabled={!canDelete}
-        >
+        <DropdownMenu.Item onSelect={onDelete} color="red" disabled={!canDelete}>
           Delete
         </DropdownMenu.Item>
       </DropdownMenu.Content>
     </DropdownMenu.Root>
   );
-};
+});
 
 export default FileTreeItemDotMenu;

--- a/src/frontend/src/pages/document/file-tree/upload-image-dialog/UploadImageDialog.tsx
+++ b/src/frontend/src/pages/document/file-tree/upload-image-dialog/UploadImageDialog.tsx
@@ -13,10 +13,7 @@ interface UploadImageDialogProps {
 const UploadImageDialog = ({ className }: UploadImageDialogProps) => {
   const [uploadedFiles, setUploadedFiles] = useState<File[]>([]);
 
-  const fileUrls = useMemo(
-    () => uploadedFiles.map((file) => URL.createObjectURL(file)),
-    [uploadedFiles],
-  );
+  const fileUrls = useMemo(() => uploadedFiles.map((file) => URL.createObjectURL(file)), [uploadedFiles]);
 
   useEffect(() => {
     return () => {

--- a/src/frontend/src/pages/document/file-tree/upload-image-dialog/UploadImageDialog.tsx
+++ b/src/frontend/src/pages/document/file-tree/upload-image-dialog/UploadImageDialog.tsx
@@ -2,7 +2,7 @@ import { Button, Card, Dialog, IconButton, Inset, Spinner, Text } from '@radix-u
 import { LucideTrash, Upload } from 'lucide-react';
 import ImageDropzone from '../../../../shared/components/ImageDropzone/ImageDropzone';
 import styles from './UploadImageDialog.module.css';
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useMemo } from 'react';
 import { useParams } from 'react-router';
 import { usePostImages } from '../../../../features/documents/api';
 
@@ -12,15 +12,17 @@ interface UploadImageDialogProps {
 
 const UploadImageDialog = ({ className }: UploadImageDialogProps) => {
   const [uploadedFiles, setUploadedFiles] = useState<File[]>([]);
-  const [fileUrls, setFileUrls] = useState<string[]>([]);
+
+  const fileUrls = useMemo(
+    () => uploadedFiles.map((file) => URL.createObjectURL(file)),
+    [uploadedFiles],
+  );
 
   useEffect(() => {
-    const urls = uploadedFiles.map((file) => URL.createObjectURL(file));
-    setFileUrls(urls);
     return () => {
-      urls.forEach((url) => URL.revokeObjectURL(url));
+      fileUrls.forEach((url) => URL.revokeObjectURL(url));
     };
-  }, [uploadedFiles]);
+  }, [fileUrls]);
 
   const documentId = useParams().documentId;
   const mutation = usePostImages(documentId!);

--- a/src/frontend/src/pages/document/file-tree/upload-image-dialog/UploadImageDialog.tsx
+++ b/src/frontend/src/pages/document/file-tree/upload-image-dialog/UploadImageDialog.tsx
@@ -2,7 +2,7 @@ import { Button, Card, Dialog, IconButton, Inset, Spinner, Text } from '@radix-u
 import { LucideTrash, Upload } from 'lucide-react';
 import ImageDropzone from '../../../../shared/components/ImageDropzone/ImageDropzone';
 import styles from './UploadImageDialog.module.css';
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import { useParams } from 'react-router';
 import { usePostImages } from '../../../../features/documents/api';
 
@@ -12,6 +12,16 @@ interface UploadImageDialogProps {
 
 const UploadImageDialog = ({ className }: UploadImageDialogProps) => {
   const [uploadedFiles, setUploadedFiles] = useState<File[]>([]);
+  const [fileUrls, setFileUrls] = useState<string[]>([]);
+
+  useEffect(() => {
+    const urls = uploadedFiles.map((file) => URL.createObjectURL(file));
+    setFileUrls(urls);
+    return () => {
+      urls.forEach((url) => URL.revokeObjectURL(url));
+    };
+  }, [uploadedFiles]);
+
   const documentId = useParams().documentId;
   const mutation = usePostImages(documentId!);
   const [open, setOpen] = useState(false);
@@ -57,7 +67,7 @@ const UploadImageDialog = ({ className }: UploadImageDialogProps) => {
                 </IconButton>
                 <Inset clip="padding-box" side="top" pb="current">
                   <img
-                    src={URL.createObjectURL(file)}
+                    src={fileUrls[index]}
                     alt={file.name}
                     style={{
                       display: 'block',

--- a/src/frontend/src/shared/components/latex-editor/EditorContext.ts
+++ b/src/frontend/src/shared/components/latex-editor/EditorContext.ts
@@ -16,9 +16,12 @@ export type AwarenessUser = {
 
 export type AwarenessUserList = Map<number, AwarenessUser>;
 
-export interface EditorContextValue {
+export interface AwarenessContextValue {
   awarenessUsers: AwarenessUserList;
   currentAwarenessUser: AwarenessUser | null;
+}
+
+export interface EditorContextValue {
   editor: MonacoEditor.IStandaloneCodeEditor | null;
   isConnected: boolean;
   setEditor: Dispatch<SetStateAction<MonacoEditor.IStandaloneCodeEditor | null>>;
@@ -34,13 +37,20 @@ export interface EditorContextValue {
 }
 
 export const EditorContext = createContext<EditorContextValue | null>(null);
+export const AwarenessContext = createContext<AwarenessContextValue | null>(null);
 
 export function useEditor() {
   const value = useContext(EditorContext);
-
   if (!value) {
     throw new Error('useEditor must be used within an EditorProvider');
   }
+  return value;
+}
 
+export function useAwareness() {
+  const value = useContext(AwarenessContext);
+  if (!value) {
+    throw new Error('useAwareness must be used within an EditorProvider');
+  }
   return value;
 }

--- a/src/frontend/src/shared/components/latex-editor/EditorProvider.tsx
+++ b/src/frontend/src/shared/components/latex-editor/EditorProvider.tsx
@@ -8,7 +8,14 @@ import * as awarenessProtocol from 'y-protocols/awareness';
 import { WebsocketProvider } from 'y-websocket';
 import * as Y from 'yjs';
 import { getDocument } from '../../../features/documents/api';
-import { EditorContext, type AwarenessUser, type AwarenessUserList, type EditorContextValue } from './EditorContext';
+import {
+  AwarenessContext,
+  EditorContext,
+  type AwarenessContextValue,
+  type AwarenessUser,
+  type AwarenessUserList,
+  type EditorContextValue,
+} from './EditorContext';
 import { useKeyboardSaveContext } from '../../../pages/document/provider/KeyboardSaveContext';
 
 import * as tableControlActions from './controls/table';
@@ -236,10 +243,8 @@ export function EditorProvider({ children, roomId }: EditorProviderProps) {
     };
   }, [yProvider]);
 
-  const value = useMemo<EditorContextValue>(
+  const editorValue = useMemo<EditorContextValue>(
     () => ({
-      awarenessUsers,
-      currentAwarenessUser,
       editor,
       isConnected: Boolean(yProvider),
       setEditor,
@@ -253,21 +258,17 @@ export function EditorProvider({ children, roomId }: EditorProviderProps) {
       insertImage,
       insertTable,
     }),
-    [
-      awarenessUsers,
-      currentAwarenessUser,
-      editor,
-      yDoc,
-      yProvider,
-      yText,
-      undo,
-      redo,
-      toggleSurroundingMacro,
-      toggleListStructure,
-      insertImage,
-      insertTable,
-    ],
+    [editor, yDoc, yProvider, yText, undo, redo, toggleSurroundingMacro, toggleListStructure, insertImage, insertTable],
   );
 
-  return <EditorContext.Provider value={value}>{children}</EditorContext.Provider>;
+  const awarenessValue = useMemo<AwarenessContextValue>(
+    () => ({ awarenessUsers, currentAwarenessUser }),
+    [awarenessUsers, currentAwarenessUser],
+  );
+
+  return (
+    <EditorContext.Provider value={editorValue}>
+      <AwarenessContext.Provider value={awarenessValue}>{children}</AwarenessContext.Provider>
+    </EditorContext.Provider>
+  );
 }

--- a/src/frontend/src/shared/components/latex-editor/EditorProvider.tsx
+++ b/src/frontend/src/shared/components/latex-editor/EditorProvider.tsx
@@ -33,17 +33,13 @@ export function EditorProvider({ children, roomId }: EditorProviderProps) {
   const undoManagerRef = useRef<Y.UndoManager | null>(null);
   const editorControlRef = useRef({ name: 'editor-control' });
 
-  const undo = useMemo(() => {
-    return () => {
-      undoManagerRef.current?.undo();
-    };
-  }, [undoManagerRef]);
+  const undo = useCallback(() => {
+    undoManagerRef.current?.undo();
+  }, []);
 
-  const redo = useMemo(() => {
-    return () => {
-      undoManagerRef.current?.redo();
-    };
-  }, [undoManagerRef]);
+  const redo = useCallback(() => {
+    undoManagerRef.current?.redo();
+  }, []);
   const { triggerSave } = useKeyboardSaveContext();
 
   const toggleSurroundingMacro = useCallback(

--- a/src/frontend/src/shared/components/latex-editor/cursor/Cursors.tsx
+++ b/src/frontend/src/shared/components/latex-editor/cursor/Cursors.tsx
@@ -1,8 +1,8 @@
 import { useMemo } from 'react';
-import { useEditor } from '../EditorContext';
+import { useAwareness } from '../EditorContext';
 
 const Cursors = () => {
-  const { awarenessUsers } = useEditor();
+  const { awarenessUsers } = useAwareness();
   const styleSheet = useMemo(() => {
     let cursorStyles = '';
 

--- a/src/frontend/src/shared/components/pdf-preview/PDFPreview.tsx
+++ b/src/frontend/src/shared/components/pdf-preview/PDFPreview.tsx
@@ -1,4 +1,4 @@
-import { useContext, useEffect, useMemo, useState, useCallback, useRef } from 'react';
+import { useContext, useEffect, useState, useCallback, useRef } from 'react';
 import {
   useGetRenderedPDF,
   COMPILE_FINISHED_MESSAGE_TYPE,
@@ -76,18 +76,19 @@ const PDFPreview = ({ docId, pdfEventSource }: PDFPreviewProps) => {
   const { data: pdfBlob, isLoading: isPdfLoading, refetch } = useGetRenderedPDF(docId);
   const themeContext = useContext(ThemeContext);
 
-  const pdfUrl = useMemo(() => {
-    if (!pdfBlob) return null;
-    return URL.createObjectURL(pdfBlob);
-  }, [pdfBlob]);
+  const [pdfUrl, setPdfUrl] = useState<string | null>(null);
 
   useEffect(() => {
+    if (!pdfBlob) {
+      setPdfUrl(null);
+      return;
+    }
+    const url = URL.createObjectURL(pdfBlob);
+    setPdfUrl(url);
     return () => {
-      if (pdfUrl) {
-        URL.revokeObjectURL(pdfUrl);
-      }
+      URL.revokeObjectURL(url);
     };
-  }, [pdfUrl]);
+  }, [pdfBlob]);
 
   useEffect(() => {
     if (!pdfEventSource) return;
@@ -132,7 +133,7 @@ const PDFPreview = ({ docId, pdfEventSource }: PDFPreviewProps) => {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       pdfEventSource.removeEventListener('error', onError as any);
     };
-  }, [docId, refetch, fetchHistory, pdfEventSource]);
+  }, [refetch, fetchHistory, pdfEventSource]);
 
   return (
     <Flex direction="column" height="100%" gap="3">

--- a/src/frontend/src/shared/components/pdf-preview/PDFPreview.tsx
+++ b/src/frontend/src/shared/components/pdf-preview/PDFPreview.tsx
@@ -1,4 +1,4 @@
-import { useContext, useEffect, useState, useCallback, useRef } from 'react';
+import { useContext, useEffect, useMemo, useState, useCallback, useRef } from 'react';
 import {
   useGetRenderedPDF,
   COMPILE_FINISHED_MESSAGE_TYPE,
@@ -76,19 +76,16 @@ const PDFPreview = ({ docId, pdfEventSource }: PDFPreviewProps) => {
   const { data: pdfBlob, isLoading: isPdfLoading, refetch } = useGetRenderedPDF(docId);
   const themeContext = useContext(ThemeContext);
 
-  const [pdfUrl, setPdfUrl] = useState<string | null>(null);
+  const pdfUrl = useMemo(() => {
+    if (!pdfBlob) return null;
+    return URL.createObjectURL(pdfBlob);
+  }, [pdfBlob]);
 
   useEffect(() => {
-    if (!pdfBlob) {
-      setPdfUrl(null);
-      return;
-    }
-    const url = URL.createObjectURL(pdfBlob);
-    setPdfUrl(url);
     return () => {
-      URL.revokeObjectURL(url);
+      if (pdfUrl) URL.revokeObjectURL(pdfUrl);
     };
-  }, [pdfBlob]);
+  }, [pdfUrl]);
 
   useEffect(() => {
     if (!pdfEventSource) return;

--- a/src/frontend/src/shared/hooks/debounce.ts
+++ b/src/frontend/src/shared/hooks/debounce.ts
@@ -1,10 +1,16 @@
-import { useRef, useCallback } from 'react';
+import { useRef, useCallback, useEffect } from 'react';
 
 export function useDebouncedCallback<TCallback extends (...args: never[]) => void>(
   callbackFn: TCallback,
   delayInMilliseconds: number,
 ) {
   const timeoutRef = useRef<number | null>(null);
+
+  useEffect(() => {
+    return () => {
+      if (timeoutRef.current) clearTimeout(timeoutRef.current);
+    };
+  }, []);
 
   const debouncedFn = useCallback(
     (...args: Parameters<TCallback>) => {


### PR DESCRIPTION
perf(frontend): fix memory leaks and reduce file-tree re-renders
  - useDebouncedCallback: clear pending timeout on unmount to prevent
    state updates on unmounted components
  - FileTreeItem: cancel requestAnimationFrame on cleanup; remove stale
    console.log; wrap in memo()
  - FileTreeItemDotMenu: wrap in memo(); pass handler refs directly to
    onSelect instead of wrapping in arrow functions
  - FileTree: stabilize callbacks with useCallback so memoized children
    can skip re-renders on unrelated parent state changes

fix(frontend): fix blob URL leaks and effect race conditions

-   URL.createObjectURL called inline in UploadImageDialog JSX leaked one URL per render with no revocation. Moved to useEffect so URLs are revoked on cleanup.

-   PDFPreview used useMemo+separate useEffect for blob URL, which is fragile under Concurrent Mode — creation and revocation split across phases. Consolidated into single useEffect with state.

-   EditorView microtask race: cleanup could run before Promise.resolve callback, leaving a closed EventSource re-set as active. Added isActive guard.

-   EditorProvider undo/redo used useMemo([undoManagerRef]) — refs are stable, so useMemo adds overhead with no benefit. Replaced with useCallback(fn, []).

-   Removed redundant docId dep from PDFPreview event-listener effect; already captured via fetchHistory which has [docId] as its dep.

perf(frontend): isolate awareness re-renders from editor context

- All useEditor() consumers re-rendered on every y-awareness change   (cursor move, collaborator join/leave) because awarenessUsers was   part of the shared context value.

- Split into AwarenessContext + useAwareness() for high-frequency awareness state, keeping EditorContext for stable editor state. Now only Cursors and EditorHeader re-render on awareness updates; controls, LatexEditor, and EditorNavigationButtons stay still.