### PR TITLE
fix(frontend): fix intercepting begin/end macros when detecting position for lists

### DIFF
--- a/src/frontend/src/shared/components/latex-editor/controls/lists.ts
+++ b/src/frontend/src/shared/components/latex-editor/controls/lists.ts
@@ -159,13 +159,40 @@ function isInsideListStructure(
     lineNumber: endMacroMatch.range.endLineNumber,
   });
 
+  // Potential intercepting macros (e.g end macros between begin macro and selection)
+  const precedingEndMacroMatch = model.findPreviousMatch(endMacro, selectionStartPosition, false, true, null, true);
+  const succeedingBeginMacroMatch = model.findNextMatch(beginMacro, selectionEndPosition, false, true, null, true);
+
+  const precedingEndMacroEndOffset = precedingEndMacroMatch
+    ? model.getOffsetAt({
+        column: precedingEndMacroMatch.range.endColumn,
+        lineNumber: precedingEndMacroMatch.range.endLineNumber,
+      })
+    : -1;
+
+  const succeedingBeginMacroStartOffset = succeedingBeginMacroMatch
+    ? model.getOffsetAt({
+        column: succeedingBeginMacroMatch.range.startColumn,
+        lineNumber: succeedingBeginMacroMatch.range.startLineNumber,
+      })
+    : Infinity;
+
   // `findPreviousMatch` and `findNextMatch` loop to the opposite side of
   // the model. To account for false-positives, check whether list structure macros
-  // are on the correct side relative to the selected range.
+  // are on the correct side relative to the selected range, without being intercepte
+  // by other macros between selection and start/end macros
+  const isBeginMacroInterceptedBeforeSelection =
+    precedingEndMacroEndOffset < selectionStartOffset && beginMacroStartOffset < precedingEndMacroEndOffset;
   const isBeginMacroBeforeSelection = beginMacroStartOffset <= selectionStartOffset;
+
+  const isEndMacroInterceptedAfterSelection =
+    succeedingBeginMacroStartOffset > selectionEndOffset && endMacroEndOffset > succeedingBeginMacroStartOffset;
   const isEndMacroAfterSelection = endMacroEndOffset >= selectionEndOffset;
 
-  const isWithinListStructure = isBeginMacroBeforeSelection && isEndMacroAfterSelection;
+  const isValidBeginMacro = !isBeginMacroInterceptedBeforeSelection && isBeginMacroBeforeSelection;
+  const isValidEndMacro = !isEndMacroInterceptedAfterSelection && isEndMacroAfterSelection;
+
+  const isWithinListStructure = isValidBeginMacro && isValidEndMacro;
 
   if (!isWithinListStructure) {
     return [false, null];


### PR DESCRIPTION
When triggering a list control, in the below example, it would check whether or not the word "four" is already inside a list. It would start scanning for `\begin` macros before the selection and for `\end` macros after the selection.

In this case it would find the `\begin` macro of the first list and the `\end` macro of the second list. But these are intercepted by their respective `\begin` and `\end` macros.

```tex
\begin{itemize}
    \item one
    \item two
    \item three
\end{itemize}


four  <---- cursor here


\begin{itemize}
    \item five
    \item six
    \item seven
\end{itemize}
```

Following this PR, it should check whether or not there are intercepting macros between the selection and `\begin` macros as well as intercepting macros between the selection and `\end` macros.