### PR TITLE
fix(editor): prevent cursor jump when Windows user joins collaborative session

### DIFF
--- a/src/frontend/src/shared/components/latex-editor/EditorProvider.tsx
+++ b/src/frontend/src/shared/components/latex-editor/EditorProvider.tsx
@@ -97,6 +97,10 @@ export function EditorProvider({ children, roomId }: EditorProviderProps) {
     });
 
     const binding = new MonacoBinding(text, model, new Set([editor]), provider.awareness);
+    // MonacoBinding's setValue('') call may reset the model EOL to the platform default (CRLF
+    // on Windows). Re-apply LF immediately while the model is still empty so no onDidChangeContent
+    // fires and _monacoChangeHandler cannot push CRLF-offset events into Y.Text.
+    model.setEOL(monaco.editor.EndOfLineSequence.LF);
     const undoManager = new Y.UndoManager(text, {
       trackedOrigins: new Set([binding, editorControlRef.current]),
     });
@@ -112,13 +116,17 @@ export function EditorProvider({ children, roomId }: EditorProviderProps) {
         const freshText = fresh.content?.replace(/\r\n/g, '\n') ?? '';
         if (freshText) text.insert(0, freshText);
       } else if (current.includes('\r\n')) {
+        // Delete \r chars individually to preserve Yjs relative positions (cursor awareness).
+        // A full delete+insert resets all connected clients' cursors to the top.
         doc.transact(() => {
-          text.delete(0, current.length);
-          text.insert(0, current.replace(/\r\n/g, '\n'));
+          let offset = 0;
+          for (const match of current.matchAll(/\r(?=\n)/g)) {
+            text.delete(match.index! - offset, 1);
+            offset++;
+          }
         });
       }
 
-      model.setEOL(monaco.editor.EndOfLineSequence.LF);
     });
 
     editor.addCommand(KeyMod.CtrlCmd | KeyCode.KeyZ, () => {

--- a/src/frontend/src/shared/components/latex-editor/EditorProvider.tsx
+++ b/src/frontend/src/shared/components/latex-editor/EditorProvider.tsx
@@ -126,7 +126,6 @@ export function EditorProvider({ children, roomId }: EditorProviderProps) {
           }
         });
       }
-
     });
 
     editor.addCommand(KeyMod.CtrlCmd | KeyCode.KeyZ, () => {


### PR DESCRIPTION
Monaco's setValue('') in MonacoBinding resets the model EOL to the
platform default (CRLF on Windows). The subsequent setEOL(LF) call in
the sync handler fired onDidChangeContent with CRLF-based offsets, which
_monacoChangeHandler pushed into Y.Text (LF-indexed). The offset mismatch
propagated to all peers and caused the Mac user's cursor to spring to top.

Three changes:
- call setEOL(LF) immediately after MonacoBinding creation (empty model →
  no change events fire, EOL reset is cancelled before content arrives)
- remove setEOL(LF) from sync handler (was the trigger for the bad events)
- replace full Y.Text delete+insert in CRLF cleanup with targeted \r
  deletions so Yjs relative positions survive and cursor is preserved