### PR TITLE
feat(frontend): support math symbol control

### DIFF
--- a/src/frontend/src/pages/document/editor-view/controls/EditorControls.tsx
+++ b/src/frontend/src/pages/document/editor-view/controls/EditorControls.tsx
@@ -4,7 +4,6 @@ import {
   LucideItalic,
   LucideList,
   LucideListOrdered,
-  LucideOmega,
   LucideSigma,
   LucideStrikethrough,
   LucideSubscript,
@@ -17,6 +16,7 @@ import { LatexMacro } from '../../../../shared/components/latex-editor/controls/
 import styles from './EditorControls.module.css';
 import FontSizeControl from './font-size/FontSizeControl';
 import { ImageSelectControl } from './image/ImageSelectControl';
+import { MathSymbolControls } from './math/MathSymbolControl';
 import { TableControl } from './table/TableControl';
 
 const EditorControls = () => {
@@ -80,9 +80,7 @@ const EditorControls = () => {
 
       <Separator orientation="vertical" />
 
-      <IconButton size="1" variant="ghost">
-        <LucideOmega size={16} />
-      </IconButton>
+      <MathSymbolControls />
       <IconButton size="1" variant="ghost">
         <LucideSigma size={16} />
       </IconButton>

--- a/src/frontend/src/pages/document/editor-view/controls/EditorControls.tsx
+++ b/src/frontend/src/pages/document/editor-view/controls/EditorControls.tsx
@@ -4,7 +4,7 @@ import {
   LucideItalic,
   LucideList,
   LucideListOrdered,
-  LucideSigma,
+  LucideOmega,
   LucideStrikethrough,
   LucideSubscript,
   LucideSuperscript,
@@ -80,10 +80,10 @@ const EditorControls = () => {
 
       <Separator orientation="vertical" />
 
-      <MathSymbolControls />
       <IconButton size="1" variant="ghost">
-        <LucideSigma size={16} />
+        <LucideOmega size={16} />
       </IconButton>
+      <MathSymbolControls />
       <Separator orientation="vertical" />
 
       <TableControl />

--- a/src/frontend/src/pages/document/editor-view/controls/math/MathSymbolControl.module.css
+++ b/src/frontend/src/pages/document/editor-view/controls/math/MathSymbolControl.module.css
@@ -1,0 +1,13 @@
+.grid {
+  display: grid;
+  grid-template-columns: repeat(10, 1fr);
+  gap: 1rem;
+  margin-bottom: 1rem;
+}
+
+.cell {
+  aspect-ratio: 1 / 1;
+  cursor: pointer;
+  display: grid;
+  place-items: center;
+}

--- a/src/frontend/src/pages/document/editor-view/controls/math/MathSymbolControl.tsx
+++ b/src/frontend/src/pages/document/editor-view/controls/math/MathSymbolControl.tsx
@@ -1,0 +1,28 @@
+import { IconButton, Popover } from '@radix-ui/themes';
+import { LucideOmega, PiIcon } from 'lucide-react';
+import { useState } from 'react';
+import { useEditor } from '../../../../../shared/components/latex-editor/EditorContext';
+
+export function MathSymbolControls() {
+  const [open, setOpen] = useState(false);
+  const { insertMathSymbol } = useEditor();
+
+  function preventPopoverFocus(event: Event) {
+    event.preventDefault();
+  }
+
+  return (
+    <Popover.Root open={open} onOpenChange={setOpen}>
+      <Popover.Trigger>
+        <IconButton size="1" variant="ghost" title="Math symbols">
+          <LucideOmega size={16} />
+        </IconButton>
+      </Popover.Trigger>
+      <Popover.Content align="end" onOpenAutoFocus={preventPopoverFocus} onCloseAutoFocus={preventPopoverFocus}>
+        <IconButton onClick={() => insertMathSymbol('\\pi')}>
+          <PiIcon />
+        </IconButton>
+      </Popover.Content>
+    </Popover.Root>
+  );
+}

--- a/src/frontend/src/pages/document/editor-view/controls/math/MathSymbolControl.tsx
+++ b/src/frontend/src/pages/document/editor-view/controls/math/MathSymbolControl.tsx
@@ -1,5 +1,5 @@
-import { IconButton, Popover } from '@radix-ui/themes';
-import { LucideSigma } from 'lucide-react';
+import { Heading, IconButton, Popover } from '@radix-ui/themes';
+import { RadicalIcon } from 'lucide-react';
 import { useState } from 'react';
 import { useEditor } from '../../../../../shared/components/latex-editor/EditorContext';
 import styles from './MathSymbolControl.module.css';
@@ -22,10 +22,11 @@ export function MathSymbolControls() {
     <Popover.Root open={open} onOpenChange={setOpen}>
       <Popover.Trigger>
         <IconButton size="1" variant="ghost" title="Math symbols">
-          <LucideSigma size={16} />
+          <RadicalIcon size={16} />
         </IconButton>
       </Popover.Trigger>
       <Popover.Content align="center" onOpenAutoFocus={preventPopoverFocus} onCloseAutoFocus={preventPopoverFocus}>
+        <Heading>Mathematical Symbols</Heading>
         <span>Basic operators</span>
         <div className={styles.grid}>
           {operators.map(({ symbol, latexSymbol, altText }) => (

--- a/src/frontend/src/pages/document/editor-view/controls/math/MathSymbolControl.tsx
+++ b/src/frontend/src/pages/document/editor-view/controls/math/MathSymbolControl.tsx
@@ -13,6 +13,11 @@ export function MathSymbolControls() {
     event.preventDefault();
   }
 
+  function insertSymbol(symbol: string) {
+    insertMathSymbol(symbol);
+    setOpen(false);
+  }
+
   return (
     <Popover.Root open={open} onOpenChange={setOpen}>
       <Popover.Trigger>
@@ -28,7 +33,7 @@ export function MathSymbolControls() {
               size="1"
               variant="outline"
               className={styles.cell}
-              onClick={() => insertMathSymbol(latexSymbol)}
+              onClick={() => insertSymbol(latexSymbol)}
               title={altText}
               aria-label={altText}
             >
@@ -44,7 +49,7 @@ export function MathSymbolControls() {
               size="1"
               variant="outline"
               className={styles.cell}
-              onClick={() => insertMathSymbol(latexSymbol)}
+              onClick={() => insertSymbol(latexSymbol)}
               title={altText}
               aria-label={altText}
             >
@@ -60,7 +65,7 @@ export function MathSymbolControls() {
               size="1"
               variant="outline"
               className={styles.cell}
-              onClick={() => insertMathSymbol(latexSymbol)}
+              onClick={() => insertSymbol(latexSymbol)}
               title={altText}
               aria-label={altText}
             >
@@ -76,7 +81,7 @@ export function MathSymbolControls() {
               size="1"
               variant="outline"
               className={styles.cell}
-              onClick={() => insertMathSymbol(latexSymbol)}
+              onClick={() => insertSymbol(latexSymbol)}
               title={altText}
               aria-label={altText}
             >
@@ -92,7 +97,7 @@ export function MathSymbolControls() {
               size="1"
               variant="outline"
               className={styles.cell}
-              onClick={() => insertMathSymbol(latexSymbol)}
+              onClick={() => insertSymbol(latexSymbol)}
               title={altText}
               aria-label={altText}
             >
@@ -108,7 +113,7 @@ export function MathSymbolControls() {
               size="1"
               variant="outline"
               className={styles.cell}
-              onClick={() => insertMathSymbol(latexSymbol)}
+              onClick={() => insertSymbol(latexSymbol)}
               title={altText}
               aria-label={altText}
             >

--- a/src/frontend/src/pages/document/editor-view/controls/math/MathSymbolControl.tsx
+++ b/src/frontend/src/pages/document/editor-view/controls/math/MathSymbolControl.tsx
@@ -1,7 +1,9 @@
 import { IconButton, Popover } from '@radix-ui/themes';
-import { LucideOmega, PiIcon } from 'lucide-react';
+import { LucideSigma } from 'lucide-react';
 import { useState } from 'react';
 import { useEditor } from '../../../../../shared/components/latex-editor/EditorContext';
+import styles from './MathSymbolControl.module.css';
+import { arrows, calculusAnalysis, logic, operators, relations, setTheory } from './math-symbols';
 
 export function MathSymbolControls() {
   const [open, setOpen] = useState(false);
@@ -15,13 +17,105 @@ export function MathSymbolControls() {
     <Popover.Root open={open} onOpenChange={setOpen}>
       <Popover.Trigger>
         <IconButton size="1" variant="ghost" title="Math symbols">
-          <LucideOmega size={16} />
+          <LucideSigma size={16} />
         </IconButton>
       </Popover.Trigger>
-      <Popover.Content align="end" onOpenAutoFocus={preventPopoverFocus} onCloseAutoFocus={preventPopoverFocus}>
-        <IconButton onClick={() => insertMathSymbol('\\pi')}>
-          <PiIcon />
-        </IconButton>
+      <Popover.Content align="center" onOpenAutoFocus={preventPopoverFocus} onCloseAutoFocus={preventPopoverFocus}>
+        <span>Basic operators</span>
+        <div className={styles.grid}>
+          {operators.map(({ symbol, latexSymbol, altText }) => (
+            <IconButton
+              size="1"
+              variant="outline"
+              className={styles.cell}
+              onClick={() => insertMathSymbol(latexSymbol)}
+              title={altText}
+              aria-label={altText}
+            >
+              {symbol}
+            </IconButton>
+          ))}
+        </div>
+
+        <span>Relations</span>
+        <div className={styles.grid}>
+          {relations.map(({ symbol, latexSymbol, altText }) => (
+            <IconButton
+              size="1"
+              variant="outline"
+              className={styles.cell}
+              onClick={() => insertMathSymbol(latexSymbol)}
+              title={altText}
+              aria-label={altText}
+            >
+              {symbol}
+            </IconButton>
+          ))}
+        </div>
+
+        <span>Arrows</span>
+        <div className={styles.grid}>
+          {arrows.map(({ symbol, latexSymbol, altText }) => (
+            <IconButton
+              size="1"
+              variant="outline"
+              className={styles.cell}
+              onClick={() => insertMathSymbol(latexSymbol)}
+              title={altText}
+              aria-label={altText}
+            >
+              {symbol}
+            </IconButton>
+          ))}
+        </div>
+
+        <span>Set theory</span>
+        <div className={styles.grid}>
+          {setTheory.map(({ symbol, latexSymbol, altText }) => (
+            <IconButton
+              size="1"
+              variant="outline"
+              className={styles.cell}
+              onClick={() => insertMathSymbol(latexSymbol)}
+              title={altText}
+              aria-label={altText}
+            >
+              {symbol}
+            </IconButton>
+          ))}
+        </div>
+
+        <span>Logic</span>
+        <div className={styles.grid}>
+          {logic.map(({ symbol, latexSymbol, altText }) => (
+            <IconButton
+              size="1"
+              variant="outline"
+              className={styles.cell}
+              onClick={() => insertMathSymbol(latexSymbol)}
+              title={altText}
+              aria-label={altText}
+            >
+              {symbol}
+            </IconButton>
+          ))}
+        </div>
+
+        <span>Calculus and analysis</span>
+        <div className={styles.grid}>
+          {calculusAnalysis.map(({ symbol, latexSymbol, altText }) => (
+            <IconButton
+              size="1"
+              variant="outline"
+              className={styles.cell}
+              onClick={() => insertMathSymbol(latexSymbol)}
+              title={altText}
+              aria-label={altText}
+            >
+              {symbol}
+            </IconButton>
+          ))}
+        </div>
       </Popover.Content>
     </Popover.Root>
   );

--- a/src/frontend/src/pages/document/editor-view/controls/math/math-symbols.tsx
+++ b/src/frontend/src/pages/document/editor-view/controls/math/math-symbols.tsx
@@ -1,0 +1,74 @@
+export interface LatexSymbol {
+  symbol: string;
+  latexSymbol: string;
+  altText: string;
+}
+
+export const operators: LatexSymbol[] = [
+  { symbol: '±', latexSymbol: '\\pm', altText: 'Plus or minus' },
+  { symbol: '∓', latexSymbol: '\\mp', altText: 'Minus or plus' },
+  { symbol: '×', latexSymbol: '\\times', altText: 'Multiplication' },
+  { symbol: '÷', latexSymbol: '\\div', altText: 'Division' },
+  { symbol: '⋅', latexSymbol: '\\cdot', altText: 'Dot multiplication' },
+  { symbol: '∗', latexSymbol: '\\ast', altText: 'Asterisk' },
+  { symbol: '∘', latexSymbol: '\\circ', altText: 'Function composition' },
+  { symbol: '√', latexSymbol: '\\sqrt{}', altText: 'Square root' },
+  { symbol: '∑', latexSymbol: '\\sum^{}_{}', altText: 'Sum' },
+  { symbol: '∏', latexSymbol: '\\prod^{}_{}', altText: 'Product' },
+];
+
+export const relations: LatexSymbol[] = [
+  { symbol: '≠', latexSymbol: '\\ne', altText: 'Not equal' },
+  { symbol: '≈', latexSymbol: '\\approx', altText: 'Approximately equal' },
+  { symbol: '∼', latexSymbol: '\\sim', altText: 'Similar' },
+  { symbol: '≃', latexSymbol: '\\simeq', altText: 'Similar or approximately equal' },
+  { symbol: '≥', latexSymbol: '\\geq', altText: 'Greater than or equal' },
+  { symbol: '≤', latexSymbol: '\\leq', altText: 'Less than or equal' },
+  { symbol: '≡', latexSymbol: '\\equiv', altText: 'Equivalent' },
+];
+
+export const arrows: LatexSymbol[] = [
+  { symbol: '→', latexSymbol: '\\rightarrow', altText: 'Right arrow' },
+  { symbol: '←', latexSymbol: '\\leftarrow', altText: 'Left arrow' },
+  { symbol: '↓', latexSymbol: '\\downarrow', altText: 'Down arrow' },
+  { symbol: '↑', latexSymbol: '\\uparrow', altText: 'Up arrow' },
+  { symbol: '↔', latexSymbol: '\\leftrightarrow', altText: 'Two-way arrow' },
+  { symbol: '⇒', latexSymbol: '\\Rightarrow', altText: 'Implies' },
+  { symbol: '⇐', latexSymbol: '\\Leftarrow', altText: 'Implied by' },
+  { symbol: '⇔', latexSymbol: '\\Leftrightarrow', altText: 'If and only if' },
+  { symbol: '↦', latexSymbol: '\\mapsto', altText: 'Maps to' },
+];
+
+export const setTheory: LatexSymbol[] = [
+  { symbol: '∈', latexSymbol: '\\in', altText: 'Element of' },
+  { symbol: '∉', latexSymbol: '\\notin', altText: 'Not element of' },
+  { symbol: '⊂', latexSymbol: '\\subset', altText: 'Subset' },
+  { symbol: '⊆', latexSymbol: '\\subseteq', altText: 'Subset or equal' },
+  { symbol: '⊄', latexSymbol: '\\not\\subset', altText: 'Not a subset' },
+  { symbol: '⊃', latexSymbol: '\\supset', altText: 'Superset' },
+  { symbol: '⊇', latexSymbol: '\\supseteq', altText: 'Superset or equal' },
+  { symbol: '∪', latexSymbol: '\\cup', altText: 'Union' },
+  { symbol: '∩', latexSymbol: '\\cap', altText: 'Intersection' },
+  { symbol: '∅', latexSymbol: '\\emptyset', altText: 'Empty set' },
+];
+
+export const logic: LatexSymbol[] = [
+  { symbol: '¬', latexSymbol: '\\neq', altText: 'Not' },
+  { symbol: '∧', latexSymbol: '\\land', altText: 'And' },
+  { symbol: '∨', latexSymbol: '\\lor', altText: 'Or' },
+  { symbol: '∀', latexSymbol: '\\forall', altText: 'For all' },
+  { symbol: '∃', latexSymbol: '\\exists', altText: 'Exists' },
+  { symbol: '∄', latexSymbol: '\\nexists', altText: 'Not exists' },
+  { symbol: '⊨', latexSymbol: '\\models', altText: 'Models / semantically entails' },
+];
+
+export const calculusAnalysis: LatexSymbol[] = [
+  { symbol: '∞', latexSymbol: '\\infty', altText: 'Infinity' },
+  { symbol: '∂', latexSymbol: '\\partial', altText: 'Partial derivative' },
+  { symbol: '∇', latexSymbol: '\\nabla', altText: 'Gradient' },
+  { symbol: '∫', latexSymbol: '\\int_{a}^{b}', altText: 'Integral' },
+  { symbol: '∬', latexSymbol: '\\iint', altText: 'Double integral' },
+  { symbol: '∭', latexSymbol: '\\iiint', altText: 'Triple integral' },
+  { symbol: '∮', latexSymbol: '\\oint', altText: 'Contour integral' },
+  { symbol: 'lim', latexSymbol: '\\lim_{x\\to\\infty}', altText: 'Limit' },
+];

--- a/src/frontend/src/shared/components/latex-editor/EditorContext.ts
+++ b/src/frontend/src/shared/components/latex-editor/EditorContext.ts
@@ -34,6 +34,7 @@ export interface EditorContextValue {
   toggleListStructure: (listStructure: LatexListStructure) => void;
   insertImage: (fileName: string) => void;
   insertTable: (dimensions: TableDimensions) => void;
+  insertMathSymbol: (symbol: string) => void;
 }
 
 export const EditorContext = createContext<EditorContextValue | null>(null);

--- a/src/frontend/src/shared/components/latex-editor/EditorProvider.tsx
+++ b/src/frontend/src/shared/components/latex-editor/EditorProvider.tsx
@@ -18,6 +18,7 @@ import {
 } from './EditorContext';
 import { useKeyboardSaveContext } from '../../../pages/document/provider/KeyboardSaveContext';
 
+import * as mathControlActions from './controls/math';
 import * as tableControlActions from './controls/table';
 import * as imageControlActions from './controls/images';
 import * as listControlActions from './controls/lists';
@@ -73,6 +74,13 @@ export function EditorProvider({ children, roomId }: EditorProviderProps) {
   const insertTable = useCallback(
     (dimensions: TableDimensions) => {
       tableControlActions.insertTable(dimensions, editor, yDoc, yText, editorControlRef);
+    },
+    [editor, yDoc, yText],
+  );
+
+  const insertMathSymbol = useCallback(
+    (symbol: string) => {
+      mathControlActions.insertSymbol(symbol, editor, yDoc, yText, editorControlRef);
     },
     [editor, yDoc, yText],
   );
@@ -264,8 +272,23 @@ export function EditorProvider({ children, roomId }: EditorProviderProps) {
       toggleListStructure,
       insertImage,
       insertTable,
+      insertMathSymbol,
     }),
-    [editor, yDoc, yProvider, yText, undo, redo, toggleSurroundingMacro, toggleListStructure, insertImage, insertTable],
+    [
+      awarenessUsers,
+      currentAwarenessUser,
+      editor,
+      yDoc,
+      yProvider,
+      yText,
+      undo,
+      redo,
+      toggleSurroundingMacro,
+      toggleListStructure,
+      insertImage,
+      insertTable,
+      insertMathSymbol,
+    ],
   );
 
   const awarenessValue = useMemo<AwarenessContextValue>(

--- a/src/frontend/src/shared/components/latex-editor/controls/math.ts
+++ b/src/frontend/src/shared/components/latex-editor/controls/math.ts
@@ -1,0 +1,140 @@
+import type { editor as MonacoEditor, Position } from 'monaco-editor';
+import type { RefObject } from 'react';
+import * as Y from 'yjs';
+
+export function insertSymbol(
+  symbol: string,
+  editor: MonacoEditor.IStandaloneCodeEditor | null,
+  yDoc: Y.Doc | null,
+  yText: Y.Text | null,
+  editorControlRef: RefObject<unknown>,
+) {
+  if (!editor || !yDoc || !yText) return;
+
+  const model = editor.getModel();
+  const position = editor.getPosition();
+
+  if (!model || !position) return;
+
+  const isMathMode = isWithinMathMode(model, position);
+  console.log(isMathMode);
+  const content = isMathMode ? symbol : `$${symbol}$`;
+  const offset = model.getOffsetAt(position);
+
+  yDoc.transact(() => {
+    yText.insert(offset, content);
+  }, editorControlRef.current);
+}
+
+interface MathDelimiter {
+  readonly opening: string;
+  readonly closing: string;
+}
+
+interface MathToken {
+  readonly delimiter: MathDelimiter;
+  readonly offset: number;
+  readonly type: 'opening' | 'closing';
+}
+
+interface MathScope {
+  readonly openingToken: MathToken;
+  readonly closingToken: MathToken;
+}
+
+const mathDelimiters: MathDelimiter[] = [
+  { opening: '$', closing: '$' },
+  { opening: '$$', closing: '$$' },
+  { opening: '\\[', closing: '\\]' },
+  { opening: '\\begin{equation}', closing: '\\end{equation}' },
+];
+
+const mathDelimiterTokens = mathDelimiters
+  .flatMap((delimiter) => [
+    { value: delimiter.opening, delimiter, type: 'opening' as const },
+    { value: delimiter.closing, delimiter, type: 'closing' as const },
+  ])
+  .sort((left, right) => right.value.length - left.value.length);
+
+export function isWithinMathMode(model: MonacoEditor.ITextModel, position: Position): boolean {
+  const cursorOffset = model.getOffsetAt(position);
+  return findMathScopeAtOffset(model.getValue(), cursorOffset) !== null;
+}
+
+function findMathScopeAtOffset(content: string, cursorOffset: number): MathScope | null {
+  const delimiterStack: MathToken[] = [];
+  let searchOffset = 0;
+
+  while (searchOffset < content.length) {
+    const token = findMathTokenAtOffset(content, searchOffset, delimiterStack);
+
+    if (!token) {
+      searchOffset++;
+      continue;
+    }
+
+    if (token.type === 'opening') {
+      delimiterStack.push(token);
+      searchOffset += token.delimiter.opening.length;
+      continue;
+    }
+
+    const openingToken = delimiterStack.at(-1);
+    if (openingToken?.delimiter === token.delimiter) {
+      delimiterStack.pop();
+
+      if (openingToken.offset < cursorOffset && cursorOffset <= token.offset) {
+        return {
+          openingToken,
+          closingToken: token,
+        };
+      }
+    }
+
+    searchOffset += token.delimiter.closing.length;
+  }
+
+  return null;
+}
+
+function findMathTokenAtOffset(content: string, offset: number, delimiterStack: MathToken[]): MathToken | null {
+  for (const tokenDefinition of mathDelimiterTokens) {
+    if (!content.startsWith(tokenDefinition.value, offset)) {
+      continue;
+    }
+
+    const tokenType = resolveTokenType(tokenDefinition, delimiterStack);
+    if (!tokenType) {
+      continue;
+    }
+
+    return {
+      delimiter: tokenDefinition.delimiter,
+      offset,
+      type: tokenType,
+    };
+  }
+
+  return null;
+}
+
+function resolveTokenType(
+  tokenDefinition: (typeof mathDelimiterTokens)[number],
+  delimiterStack: MathToken[],
+): MathToken['type'] | null {
+  const latestOpeningToken = delimiterStack.at(-1);
+
+  if (tokenDefinition.delimiter.opening === tokenDefinition.delimiter.closing) {
+    return latestOpeningToken?.delimiter === tokenDefinition.delimiter ? 'closing' : 'opening';
+  }
+
+  if (tokenDefinition.type === 'opening') {
+    return 'opening';
+  }
+
+  if (latestOpeningToken?.delimiter === tokenDefinition.delimiter) {
+    return 'closing';
+  }
+
+  return null;
+}


### PR DESCRIPTION
Inserts a math block, if not already inside of an inline or multi-line block.
Following block types for this detection are supported:
- `$ $` (inline)
- `$$ $$` (inline or multiline)
- `\[ \]` (inline or multiline)
- `\begin{equation} \end{equation}` (inline or multiline)

<img width="455" height="476" alt="image" src="https://github.com/user-attachments/assets/3760de0c-82c4-4827-af79-07296fc86703" />
